### PR TITLE
Fix for 'Null check operator used on a null value'

### DIFF
--- a/lib/gif_view.dart
+++ b/lib/gif_view.dart
@@ -147,7 +147,7 @@ class GifView extends StatefulWidget {
 
 class GifViewState extends State<GifView> with TickerProviderStateMixin {
   late GifController controller;
-  late AnimationController _animationController;
+  AnimationController? _animationController;
 
   @override
   void initState() {
@@ -271,14 +271,15 @@ class GifViewState extends State<GifView> with TickerProviderStateMixin {
   FutureOr _loadImage({bool updateFrames = false}) async {
     final frames = await _fetchGif(widget.image);
     controller.configure(frames, updateFrames: updateFrames);
-    _animationController.forward(from: 0);
+    _animationController?.forward(from: 0);
   }
 
   @override
   void dispose() {
     controller.stop();
     controller.removeListener(_listener);
-    _animationController.dispose();
+    _animationController?.dispose();
+    _animationController = null;
     super.dispose();
   }
 


### PR DESCRIPTION
The issue:
When GifView is loading a gif in list tiles, sometimes on scroll there are errors like this:
```
Null check operator used on a null value

#0      AnimationController.stop (package:flutter/src/animation/animation_controller.dart:785)
#1      AnimationController.value= (package:flutter/src/animation/animation_controller.dart:367)
#2      AnimationController.forward (package:flutter/src/animation/animation_controller.dart:465)
#3      GifViewState._loadImage (package:gif_view/gif_view.dart:274)
<asynchronous suspension>
```

The problem is that methods such as `.forward` should not be called on animation controller after it's been disposed. 

This small fix should eliminate the problem.